### PR TITLE
Update spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ It could be useful to see how fast tests run.  The log output should include tes
 
 ### Language
 
-The framework should be written in TypeScript.
+The framework should be written in Rust.
 
-- Framework should be test runner agnostic
-- Include Chai assertions
+- Unit tests themselves will be written in AssemblyScript and compiled to wasm.
+- The framework will be used via CLI.
 
 ### Performance
 
@@ -73,6 +73,4 @@ The framework should be tested with coverage exceeding 90%
 
 ## Scope and Budget
 
-Estimated dev time: 3 weeks
-
-20000 GRT
+N/A


### PR DESCRIPTION
Updating the spec as per the last LimeChain<->Graph foundation meeting. The main change is switching from TypeScript to Rust for implementing the test framework itself, and from TypeScript to AssemblyScript for writing the unit tests (by the end user). The reasoning for this consists of 2 main points: 
- Both AS and Rust compile to WASM and therefore interoperability is easier than using a JS/TS bridge.
- The host functions which will be needed to instantiate and work with the wasm mapping files are already defined in Rust within the graph-node repo, so it makes sense to just import them from there, and then mock what's left, according to our needs (e.g. the store object).